### PR TITLE
updated pricing 

### DIFF
--- a/units.json
+++ b/units.json
@@ -34,7 +34,7 @@
   },
   {
     "name": "CH-47F Chinook",
-    "kaufpreis": 66000000,
+    "kaufpreis": 83333333,
     "url": "https://de.wikipedia.org/wiki/Boeing-Vertol_CH-47",
     "soldaten": 4,
     "icon": "🚁",

--- a/units.json
+++ b/units.json
@@ -102,5 +102,13 @@
     "soldaten": 5,
     "icon": "🚢",
     "wartung_pro_jahr": 10000
+  },
+  {
+    "name": "Arrow 3 or Hetz 3",
+    "kaufpreis": 3000000,
+    "url": "https://en.wikipedia.org/wiki/Arrow_3",
+    "soldaten": 5,
+    "icon": "🚢",
+    "wartung_pro_jahr": 266666666
   }
 ]


### PR DESCRIPTION
according to
https://www.faz.net/aktuell/politik/inland/sondervermoegen-bundeswehr-soll-chinook-hubschrauber-bekommen-18071569.html